### PR TITLE
refactor : deploy.yml 수정 - 멀티라인 YAML 줄바꿈 보존 방식으로 생성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    if: github.repository == 'Team-Promesa/spring-vote-21st'  
+    if: github.repository == 'Team-Promesa/spring-vote-21st'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,10 +45,20 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             cd /home/ubuntu/
+
+            # .env 파일 생성
             echo "${{ secrets.ENV_VARS }}" | sudo tee .env > /dev/null
-            echo "${{ vars.DOCKER_COMPOSE }}" | sudo tee docker-compose.yml > /dev/null
+
+            # DOCKER_COMPOSE 멀티라인 YAML 줄바꿈 보존 방식으로 생성
+            cat <<EOF | sudo tee docker-compose.yml > /dev/null
+${{ vars.DOCKER_COMPOSE }}
+EOF
+
+            # 도커 권한 및 이미지 정리
             sudo chmod 666 /var/run/docker.sock
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f $(docker ps -qa) || true
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/vote
-            docker-compose -f docker-compose.yml --env-file ./.env up -d
-            docker image prune -f
+
+            # 컨테이너 실행 및 확인
+            sudo docker-compose -f docker-compose.yml --env-file .env up -d || exit 1
+            sudo docker ps -a


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #{$이슈 번호}

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- workflow파일에서
 **DOCKER_COMPOSE 멀티라인 YAML 줄바꿈 보존 방식**으로 생성

![image](https://github.com/user-attachments/assets/984bc3de-f97c-46e3-8118-afd9e5ca198e)
-> github actions에는 "3"으로 저장한 것이
![image](https://github.com/user-attachments/assets/f45f4084-53ec-4ded-9c76-0d3940458c90)
->docker-compose.yml에는 그냥 3으로 인식돼서 저장
![image](https://github.com/user-attachments/assets/f61b3e0d-3bf9-4c80-b336-c5a8f16305b9)
-> 그래서 자꾸 에러가 나고 컨테이너 생성 실행이 안됨 

🔍 왜 version: "3"이 "3" → 3으로 바뀌는가?
  문제는 GitHub Actions의 ${{ vars.DOCKER_COMPOSE }} 값이 YAML 내부에서 줄바꿈 없이 "문자열로 처리되면서",
  EC2에서 echo나 tee로 쓸 때 YAML 구조가 망가지는 현상

✴️ 예전 방식:
`echo "${{ vars.DOCKER_COMPOSE }}" | sudo tee docker-compose.yml > /dev/null`
→ 이건 GitHub Actions가 환경변수 값 전체를 한 줄로 처리하는 성질 때문에,
"3" 같은 값이 줄바꿈/들여쓰기 없이 3 (숫자)로 처리됨 -> YAML 문법 에러


---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
